### PR TITLE
Fix a few clippy lints

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -26,14 +26,14 @@ pub(crate) struct Choice {
 impl Choice {
     pub(crate) fn external(text: String, name: NodeName) -> Choice {
         Choice {
-            text: text,
+            text,
             kind: ChoiceKind::External(name),
         }
     }
 
     pub(crate) fn inline(text: String, steps: Vec<Step>, condition: Option<Expr>) -> Choice {
         Choice {
-            text: text,
+            text,
             kind: ChoiceKind::Inline(steps, condition),
         }
     }
@@ -376,7 +376,7 @@ impl NodeState {
         };
         let mut current_step_index = conversation.base_index;
 
-        for index in conversation.indexes.iter() {
+        for index in &conversation.indexes {
             match (&steps[current_step_index], *index) {
                 (&Step::Dialogue(_, ref choices), StepIndex::Dialogue(choice, step_index)) => {
                     let choice = &choices[choice];
@@ -457,7 +457,7 @@ impl YarnEngine {
         callback: Box<FunctionCallback>,
     ) {
         self.engine_state.functions.insert(name, Function {
-            num_args: num_args,
+            num_args,
             callback,
         });
     }
@@ -485,8 +485,8 @@ impl YarnEngine {
         let conversation = {
             let mut conversation = self.state.take_conversation();
             let (steps, current_step_index) = self.state.get_current_step(&conversation);
-            match &steps[current_step_index] {
-                &Step::Dialogue(_, ref choices) => {
+            match steps[current_step_index] {
+                Step::Dialogue(_, ref choices) => {
                     match choices[choice].kind {
                         ChoiceKind::External(ref node) => conversation.reset((*node).clone()),
                         ChoiceKind::Inline(..) => {
@@ -494,7 +494,7 @@ impl YarnEngine {
                         }
                     }
                 }
-                &Step::Command(..) | &Step::Assign(..) | &Step::Conditional(..) | &Step::Jump(..) =>
+                Step::Command(..) | Step::Assign(..) | Step::Conditional(..) | Step::Jump(..) =>
                     unreachable!(),
             }
             conversation

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -555,11 +555,7 @@ impl<'a> Iterator for TokenIterator<'a> {
                 '0'...'9' => {
                     buffer.push(ch);
                     let mut before_decimal = true;
-                    loop {
-                        let ch = match self.next_char() {
-                            Some(ch) => ch,
-                            None => break,
-                        };
+                    while let Some(ch) = self.next_char() {
                         match ch {
                             '0'...'9' => buffer.push(ch),
                             '.' if before_decimal => {


### PR DESCRIPTION
I pulled the code to have a play around with things (trying to decide if I want to roll with Yarn or try to write an equivilant kind of crate for Ink or Twine), and noticed a couple of Clippy warnings - figured I might as well fix them while I was at it 😄 

There were also a few warnings for 'unneeded return statement' (i.e. not using implicit returns), but I wasn't sure if that was just your personal preference, so I left them as is - I can change them too if you want, though!